### PR TITLE
Add support for vector blocks as main component.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,6 @@ Known limitations
 Planned Improvements
 --------------------
 
- [ ] `VectorBlocks` should be considered as a Component Type on their own.
+ [ ] Create a new store for Vectors, to have statistics on their size, ref count, ...
  [ ] Display and use the consumed On-heap memory reported by the Memory Analysis.
  

--- a/src/main/java/com/activeviam/mac/memory/MemoryAnalysisDatastoreDescription.java
+++ b/src/main/java/com/activeviam/mac/memory/MemoryAnalysisDatastoreDescription.java
@@ -31,6 +31,9 @@ import com.quartetfs.fwk.format.IParser;
  */
 public class MemoryAnalysisDatastoreDescription implements IDatastoreSchemaDescription {
 
+	/** Constant enabling the creation of Debug tree for each info, stored in the Datastore. */
+	public static final boolean ADD_DEBUG_TREE = false;
+
 	/**
 	 * Name of the chunk <-> provider linking store
 	 */
@@ -133,7 +136,7 @@ public class MemoryAnalysisDatastoreDescription implements IDatastoreSchemaDescr
 				.withField(DatastoreConstants.CHUNK__NON_WRITTEN_ROWS, ILiteralType.LONG)
 				.withField(DatastoreConstants.CHUNK__FREE_ROWS, ILiteralType.LONG)
 
-				.withField(DatastoreConstants.CHUNK__DEBUG_TREE, ILiteralType.STRING)
+				.withNullableField(DatastoreConstants.CHUNK__DEBUG_TREE, ILiteralType.STRING)
 
 				.withDuplicateKeyHandler(new ChunkRecordHandler())
 				.build();

--- a/src/main/java/com/activeviam/mac/statistic/memory/visitor/impl/DatastoreFeederVisitor.java
+++ b/src/main/java/com/activeviam/mac/statistic/memory/visitor/impl/DatastoreFeederVisitor.java
@@ -145,8 +145,10 @@ public class DatastoreFeederVisitor extends ADatastoreFeedVisitor<Void> {
 		FeedVisitor.setTupleElement(tuple, chunkRecordFormat, DatastoreConstants.CHUNK__OWNER, this.store);
 		FeedVisitor.setTupleElement(tuple, chunkRecordFormat, DatastoreConstants.CHUNK__COMPONENT, this.rootComponent);
 		tuple[chunkRecordFormat.getFieldIndex(DatastoreConstants.CHUNK__PARTITION_ID)] = this.partitionId;
-		tuple[chunkRecordFormat.getFieldIndex(DatastoreConstants.CHUNK__DEBUG_TREE)] = StatisticTreePrinter
-				.getTreeAsString(chunkStatistic);
+		if (MemoryAnalysisDatastoreDescription.ADD_DEBUG_TREE) {
+			tuple[chunkRecordFormat.getFieldIndex(DatastoreConstants.CHUNK__DEBUG_TREE)] = StatisticTreePrinter
+					.getTreeAsString(chunkStatistic);
+		}
 
 		FeedVisitor.add(chunkStatistic, this.transaction, DatastoreConstants.CHUNK_STORE, tuple);
 

--- a/src/main/java/com/activeviam/mac/statistic/memory/visitor/impl/VectorStatisticVisitor.java
+++ b/src/main/java/com/activeviam/mac/statistic/memory/visitor/impl/VectorStatisticVisitor.java
@@ -1,0 +1,175 @@
+/*
+ * (C) ActiveViam 2019
+ * ALL RIGHTS RESERVED. This material is the CONFIDENTIAL and PROPRIETARY
+ * property of ActiveViam. Any unauthorized use,
+ * reproduction or transfer of this material is strictly prohibited
+ */
+package com.activeviam.mac.statistic.memory.visitor.impl;
+
+import java.time.Instant;
+
+import com.activeviam.mac.memory.DatastoreConstants;
+import com.activeviam.mac.memory.MemoryAnalysisDatastoreDescription;
+import com.activeviam.mac.memory.MemoryAnalysisDatastoreDescription.ParentType;
+import com.qfs.monitoring.statistic.memory.IMemoryStatistic;
+import com.qfs.monitoring.statistic.memory.MemoryStatisticConstants;
+import com.qfs.monitoring.statistic.memory.impl.ChunkSetStatistic;
+import com.qfs.monitoring.statistic.memory.impl.ChunkStatistic;
+import com.qfs.monitoring.statistic.memory.impl.DefaultMemoryStatistic;
+import com.qfs.monitoring.statistic.memory.impl.DictionaryStatistic;
+import com.qfs.monitoring.statistic.memory.impl.IndexStatistic;
+import com.qfs.monitoring.statistic.memory.impl.ReferenceStatistic;
+import com.qfs.store.IDatastoreSchemaMetadata;
+import com.qfs.store.record.IRecordFormat;
+import com.qfs.store.transaction.IOpenedTransaction;
+
+/**
+ *  Implementation of the {@link IMemoryStatisticVisitor} class for Vectors.
+ * @author ActiveViam
+ *
+ */
+public class VectorStatisticVisitor extends ADatastoreFeedVisitor<Void> {
+
+	/** The record format of the store that stores the chunks. */
+	protected final IRecordFormat chunkRecordFormat;
+
+	/** The export date, found on the first statistics we read */
+	protected final Instant current;
+
+	/** Root component owning the vector. */
+	private final ParentType rootComponent;
+	/** Type of the parent holding the instance of Vector. */
+	private final ParentType directParentType;
+	/** Id of the parent holding the instance of Vector. */
+	private final String directParentId;
+	/** The partition id of the visited statistic */
+	protected final int partitionId;
+
+	/**
+	 * Constructor
+	 * @param storageMetadata metadata of the application datastore
+	 * @param transaction ongoing transaction
+	 * @param dumpName name of the ongoing import
+	 * @param current current time
+	 * @param store store being visited
+	 * @param rootComponent highest component holding the ChunkSet
+	 * @param parentType structure type of the parent of the Chunkset
+	 * @param parentId id of the parent of the ChunkSet
+	 * @param partitionId partition id of the parent if the chunkSet
+	 */
+	public VectorStatisticVisitor(
+			final IDatastoreSchemaMetadata storageMetadata,
+			final IOpenedTransaction transaction,
+			final String dumpName,
+			final Instant current,
+			final String store,
+			final ParentType rootComponent,
+			final ParentType parentType,
+			final String parentId,
+			final int partitionId) {
+		super(transaction, storageMetadata, dumpName);
+		this.current = current;
+		this.store = store;
+		this.rootComponent = rootComponent;
+		this.directParentType = parentType;
+		this.directParentId = parentId;
+		this.partitionId = partitionId;
+
+		this.chunkRecordFormat = this.storageMetadata
+				.getStoreMetadata(DatastoreConstants.CHUNK_STORE)
+				.getStoreFormat()
+				.getRecordFormat();
+	}
+
+	/**
+	 * Tests if a statistic represents a Vector.
+	 * @param statistic instance to test
+	 * @return true for a Vector, that this Visitor must handle
+	 */
+	static boolean isVector(final IMemoryStatistic statistic) {
+		return statistic.getName().equals(MemoryStatisticConstants.STAT_NAME_CHUNK_ENTRY)
+				&& statistic.getAttributes().containsKey(MemoryStatisticConstants.ATTR_NAME_VECTOR_OFFHEAP_PRINT);
+	}
+
+	/**
+	 * Process the Vector element and all its children.
+	 * @param statistic root statistic
+	 */
+	public void process(final IMemoryStatistic statistic) {
+		statistic.accept(this);
+	}
+
+	@Override
+	public Void visit(DefaultMemoryStatistic memoryStatistic) {
+		// TODO we could store the information on that vector in another dedicated store.
+		FeedVisitor.visitChildren(this, memoryStatistic);
+		return null;
+	}
+
+	@Override
+	public Void visit(final ChunkStatistic chunkStatistic) {
+		if (chunkStatistic.getName().equals(MemoryStatisticConstants.STAT_NAME_VECTOR_BLOCK)) {
+			visitVectorBlock(chunkStatistic);
+		} else {
+			throw new IllegalStateException(
+					"Unexpected statistics for chunks. Got " + chunkStatistic +
+							"from " + StatisticTreePrinter.getTreeAsString(chunkStatistic));
+		}
+		return null;
+	}
+
+	// NOT RELEVANT
+
+	@Override
+	public Void visit(final ChunkSetStatistic statistic) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Void visit(ReferenceStatistic referenceStatistic) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Void visit(IndexStatistic indexStatistic) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Void visit(DictionaryStatistic dictionaryStatistic) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Visits a chunk containing only vectors.
+	 * <p>
+	 * This is the actual block containing all the data stored in various vectors, not the objects representing vectors.
+	 * </p>
+	 * @param statistic statistics about a block of vector items.
+	 */
+	protected void visitVectorBlock(final ChunkStatistic statistic) {
+		assert statistic.getChildren().isEmpty() : "Vector statistics with children";
+
+		final IRecordFormat format = this.chunkRecordFormat;
+		final Object[] tuple = FeedVisitor.buildChunkTupleFrom(format, statistic);
+
+		FeedVisitor.setTupleElement(tuple, format, DatastoreConstants.CHUNK__PARENT_TYPE, ParentType.VECTOR_BLOCK);
+		FeedVisitor.setTupleElement(tuple, format, DatastoreConstants.CHUNK__PARENT_ID, "None");
+
+		FeedVisitor.setTupleElement(tuple, format, DatastoreConstants.CHUNK__DUMP_NAME, this.dumpName);
+
+		FeedVisitor.setTupleElement(tuple, format, DatastoreConstants.CHUNK__OWNER, this.store);
+		FeedVisitor.setTupleElement(tuple, format, DatastoreConstants.CHUNK__COMPONENT, ParentType.VECTOR_BLOCK);
+		FeedVisitor.setTupleElement(tuple, format, DatastoreConstants.CHUNK__PARTITION_ID, this.partitionId);
+
+		// Debug
+		if (MemoryAnalysisDatastoreDescription.ADD_DEBUG_TREE) {
+			tuple[format.getFieldIndex(DatastoreConstants.CHUNK__DEBUG_TREE)] = StatisticTreePrinter.getTreeAsString(statistic);
+		}
+
+		FeedVisitor.add(statistic, this.transaction, DatastoreConstants.CHUNK_STORE, tuple);
+
+		visitChildren(statistic);
+	}
+
+}

--- a/src/test/java/com/activeviam/mac/statistic/memory/ATestMemoryStatistic.java
+++ b/src/test/java/com/activeviam/mac/statistic/memory/ATestMemoryStatistic.java
@@ -761,7 +761,7 @@ public abstract class ATestMemoryStatistic {
 				.buildAndStart());
 	}
 
-	static void assertLoadsCorrectly(final Collection<? extends IMemoryStatistic> statistics, Class<?> klass) {
+	static IDatastore assertLoadsCorrectly(final Collection<? extends IMemoryStatistic> statistics, Class<?> klass) {
 		final IDatastore monitoringDatastore = createAnalysisDatastore();
 
 		monitoringDatastore.edit(tm -> {
@@ -780,6 +780,8 @@ public abstract class ATestMemoryStatistic {
 
 		checkForUnclassifiedChunks(monitoringDatastore);
 		checkForUnrootedChunks(monitoringDatastore);
+
+		return monitoringDatastore;
 	}
 
 	static void checkForUnclassifiedChunks(IDatastore monitoringDatastore) {


### PR DESCRIPTION
The next step would be to spend time referencing each vector in a
dedicated table.
This would offer statistics on vector size, type, reference count.