### PR TITLE
Detect chunk of single vector.

### DIFF
--- a/src/main/java/com/activeviam/mac/statistic/memory/visitor/impl/VectorStatisticVisitor.java
+++ b/src/main/java/com/activeviam/mac/statistic/memory/visitor/impl/VectorStatisticVisitor.java
@@ -85,8 +85,8 @@ public class VectorStatisticVisitor extends ADatastoreFeedVisitor<Void> {
   }
 
   /**
-   * Tests if the name of the statistic is matching the list of known entities representing
-   * vectors.
+   * Tests if the name of the statistic is matching the list of known entities representing vectors.
+   *
    * @param statisticName name of the visited statistic
    * @return true for a stat on a vector
    */

--- a/src/test/java/com/activeviam/mac/statistic/memory/ATestMemoryStatistic.java
+++ b/src/test/java/com/activeviam/mac/statistic/memory/ATestMemoryStatistic.java
@@ -636,6 +636,12 @@ public abstract class ATestMemoryStatistic {
     return d;
   }
 
+  /**
+   * Creates a minimal application with a single store {@link #VECTOR_STORE_NAME} with the following
+   * fields: - vectorId - int - vectorInt1 - int[] (block of 35 entries) - vectorInt2 - int[]
+   * (blocks of 20 entries) - vectorLong - long[] (blocks of 30 entries) The store has chunks of 10
+   * rows.
+   */
   static void createApplicationWithVector(
       final boolean useVectorsAsMeasures,
       final ThrowingLambda.ThrowingBiConsumer<IDatastore, IActivePivotManager> actions) {
@@ -652,6 +658,7 @@ public abstract class ATestMemoryStatistic {
                     .withVectorBlockSize(20)
                     .withVectorField("vectorLong", ILiteralType.LONG)
                     .withVectorBlockSize(30)
+                    .withChunkSize(16) // Make it easy to fill a complete block
                     .build())
             .build();
     final var userManagerDescription =


### PR DESCRIPTION

************************

Basically, for chunks with vectors, we export the statistic of the chunk itself and the statistics of the **blocks** of vectors.
Older versions - 5.8.4 and before - were also exporting every vector in the chunk.

For the special case of chunks filled with a single value that is a vector, we export the chunk statistic with a **vector** as its only child. Thus, we are in the same case of 5.8.4- versions.
Instead of changing the exported format, we change adapt the support of old versions to this new case.