### PR TITLE
Ignore conflicting slicing hierarchies in smart filtering.

### DIFF
--- a/src/main/java/com/activeviam/mac/cfg/impl/ManagerDescriptionConfig.java
+++ b/src/main/java/com/activeviam/mac/cfg/impl/ManagerDescriptionConfig.java
@@ -30,6 +30,7 @@ import com.activeviam.mac.memory.MemoryAnalysisDatastoreDescription.ParentType;
 import com.qfs.agg.impl.SingleValueFunction;
 import com.qfs.desc.IDatastoreSchemaDescription;
 import com.qfs.literal.ILiteralType;
+import com.qfs.multiversion.IEpoch;
 import com.qfs.pivot.util.impl.MdxNamingUtil;
 import com.qfs.server.cfg.IActivePivotManagerDescriptionConfig;
 import com.quartetfs.biz.pivot.context.impl.QueriesTimeLimit;
@@ -42,6 +43,7 @@ import com.quartetfs.biz.pivot.definitions.ISelectionDescription;
 import com.quartetfs.biz.pivot.impl.ActivePivotManagerBuilder;
 import com.quartetfs.fwk.format.impl.DateFormatter;
 import com.quartetfs.fwk.format.impl.NumberFormatter;
+import com.quartetfs.fwk.ordering.impl.NaturalOrderComparator;
 import com.quartetfs.fwk.ordering.impl.ReverseOrderComparator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -319,7 +321,7 @@ public class ManagerDescriptionConfig implements IActivePivotManagerDescriptionC
         .slicing()
         .withLevelOfSameName()
         .withPropertyName(DatastoreConstants.CHUNK__DUMP_NAME)
-        .withComparator(ReverseOrderComparator.type)
+        .withComparator(NaturalOrderComparator.type)
         .withHierarchy(DATE_HIERARCHY)
         .withLevelOfSameName()
         .withPropertyName(DatastoreConstants.APPLICATION__DATE)
@@ -349,6 +351,7 @@ public class ManagerDescriptionConfig implements IActivePivotManagerDescriptionC
         .slicing()
         .withLevel(BRANCH_HIERARCHY)
         .withPropertyName(DatastoreConstants.VERSION__BRANCH_NAME)
+        .withFirstObjects(IEpoch.MASTER_BRANCH_NAME)
         .withSingleLevelHierarchy(USED_BY_VERSION_DIMENSION)
         .withPropertyName(DatastoreConstants.CHUNK__USED_BY_VERSION)
         .withDimension(OWNER_DIMENSION)

--- a/src/main/resources/bookmarks/settings.json
+++ b/src/main/resources/bookmarks/settings.json
@@ -1,1 +1,87 @@
-{"entry":{"isDirectory":true,"owners":["ROLE_CS_ROOT"],"readers":["ROLE_USER"]},"children":{"default":{"entry":{"isDirectory":true,"owners":["ROLE_CS_ROOT"],"readers":["ROLE_USER"]},"children":{"preferences":{"entry":{"content":"{\n  \"allow\": [],\n  \"deny\": [],\n  \"map\": {}\n}","isDirectory":false,"owners":["ROLE_CS_ROOT"],"readers":["ROLE_USER"]}}}},"users":{"entry":{"isDirectory":true,"owners":["ROLE_USER"],"readers":["ROLE_USER"]},"children":{"admin":{"entry":{"isDirectory":true,"owners":["admin"],"readers":["admin"]},"children":{"preferences":{"entry":{"content":"{\n  \"map\": {\n    \"defaultPermissions\": {\n      \"owners\": [\n        \"admin\"\n      ],\n      \"readers\": [\n        \"admin\"\n      ]\n    }\n  }\n}","isDirectory":false,"owners":["admin"],"readers":["admin"]}}}}}},"roles":{"entry":{"isDirectory":true,"owners":["ROLE_CS_ROOT"],"readers":["ROLE_USER"]}}}}
+{
+  "entry": {
+    "isDirectory": true,
+    "owners": [
+      "ROLE_CS_ROOT"
+    ],
+    "readers": [
+      "ROLE_USER"
+    ]
+  },
+  "children": {
+    "default": {
+      "entry": {
+        "isDirectory": true,
+        "owners": [
+          "ROLE_CS_ROOT"
+        ],
+        "readers": [
+          "ROLE_USER"
+        ]
+      },
+      "children": {
+        "preferences": {
+          "entry": {
+            "content": "{\n  \"allow\": [],\n  \"deny\": [],\n  \"map\": {\n    \"memberSelection.smartFiltering\": true,\n    \"memberSelection.smartFiltering.[Import info].[Import info]\": false,\n    \"memberSelection.smartFiltering.[Versions].[Branch]\": false\n  }\n}",
+            "isDirectory": false,
+            "owners": [
+              "ROLE_CS_ROOT"
+            ],
+            "readers": [
+              "ROLE_USER"
+            ]
+          }
+        }
+      }
+    },
+    "users": {
+      "entry": {
+        "isDirectory": true,
+        "owners": [
+          "ROLE_USER"
+        ],
+        "readers": [
+          "ROLE_USER"
+        ]
+      },
+      "children": {
+        "admin": {
+          "entry": {
+            "isDirectory": true,
+            "owners": [
+              "admin"
+            ],
+            "readers": [
+              "admin"
+            ]
+          },
+          "children": {
+            "preferences": {
+              "entry": {
+                "content": "{\n  \"map\": {\n    \"defaultPermissions\": {\n      \"owners\": [\n        \"admin\"\n      ],\n      \"readers\": [\n        \"admin\"\n      ]\n    }\n  }\n}",
+                "isDirectory": false,
+                "owners": [
+                  "admin"
+                ],
+                "readers": [
+                  "admin"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "roles": {
+      "entry": {
+        "isDirectory": true,
+        "owners": [
+          "ROLE_CS_ROOT"
+        ],
+        "readers": [
+          "ROLE_USER"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
The combination of the two hierarchies was creating cases where no data where display, because the filters where creating empty results.
In addition, we order the Branch hierarchy to have master as the first value, picked to be the default member. This is a sensible choice because every dump will have it as a branch.
