### PR TITLE
Using AP 5.9 for MAC 5.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <jdk.version>11</jdk.version>
 
-    <activepivot.version>5.8.17-jdk11</activepivot.version>
+    <activepivot.version>5.9.8</activepivot.version>
     <activeui.version>4.3.16</activeui.version>
     <content-server-ui.version>1.1.2</content-server-ui.version>
 


### PR DESCRIPTION
This version of MAC is made for people using AP 5.8, but our MAC is using functionality only available starting from 5.9. With AP 5.9 in MAC 5.8, we are able to read exports from AP 5.9

We should use AP 5.9 in this version of MAC, as its goal is to be able to read export of AP 5.8 and not use the corresponding AP version in MAC.